### PR TITLE
Return Error instead of panicking when parsing something that isn't an RSS feed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,7 @@ impl ViaXml for Rss {
 
     fn from_xml(rss_elem: Element) -> Result<Self, &'static str> {
         if rss_elem.name.to_ascii_lowercase() != "rss" {
-            panic!("Expected <rss>, found <{}>", rss_elem.name);
+            return Err("Top element is not <rss>, most likely not an RSS feed");
         }
 
         let channel_elem = match rss_elem.get_child("channel", None) {


### PR DESCRIPTION
There's no good reason to panic in a function that returns a `Result`. This function is used in the `FromStr` implementation as well, which isn't supposed to panic on invalid input; instead, it returns some sensible `Err` value explaining why it couldn't parse the input data.