### PR TITLE
Fix non sized warning for ViaXml

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ fn elem_with_text(tag_name: &'static str, chars: &str) -> Element {
 }
 
 
-trait ViaXml {
+trait ViaXml : Sized {
     fn to_xml(&self) -> Element;
     fn from_xml(elem: Element) -> Result<Self, ReadError>;
 }


### PR DESCRIPTION
Tiny PR fixing a warning in advance before it becomes a *HARD ERROR* in the next release.
```
src/lib.rs:117:5: 117:59 warning: the trait `core::marker::Sized` is not implemented for the type `Self` [E0277]
src/lib.rs:117     fn from_xml(elem: Element) -> Result<Self, ReadError>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:117:5: 117:59 help: run `rustc --explain E0277` to see a detailed explanation
src/lib.rs:117:5: 117:59 note: `Self` does not have a constant size known at compile-time
src/lib.rs:117:5: 117:59 note: this warning results from recent bug fixes and clarifications; it will become a HARD ERROR in the next release. See RFC 1214 for details.
src/lib.rs:117     fn from_xml(elem: Element) -> Result<Self, ReadError>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```