### PR TITLE
Implement item/guid spec

### DIFF
--- a/src/guid.rs
+++ b/src/guid.rs
@@ -1,0 +1,38 @@
+use xml::Element;
+
+use ::{ReadError, ViaXml};
+
+/// [RSS 2.0 Specification § `<guid>` sub-element of `<item>`]
+/// (http://cyber.law.harvard.edu/rss/rss.html#ltguidgtSubelementOfLtitemgt)
+#[derive(Debug, Clone)]
+pub struct Guid {
+    pub is_perma_link: bool,
+    pub value: String,
+}
+
+impl ViaXml for Guid {
+    fn to_xml(&self) -> Element {
+        let mut guid = if !self.is_perma_link {
+            Element::new("guid".to_string(), None, vec![("isPermaLink".to_string(), None, "false".to_string())])
+        } else {
+            Element::new("guid".to_string(), None, vec![])
+        };
+
+        guid.text(self.value.clone());
+        guid
+    }
+
+    fn from_xml(elem: Element) -> Result<Self, ReadError> {
+        let is_perma_link = match elem.get_attribute("isPermaLink", None) {
+            Some("false") => false,
+            _ => true
+        };
+
+        let value = elem.content_str();
+
+        Ok(Guid {
+            is_perma_link: is_perma_link,
+            value: value,
+        })
+    }
+}

--- a/src/item.rs
+++ b/src/item.rs
@@ -14,7 +14,7 @@
 
 use xml::Element;
 
-use ::{Category, ElementUtils, ReadError, ViaXml};
+use ::{Category, Guid, ElementUtils, ReadError, ViaXml};
 
 
 /// [RSS 2.0 Specification § Elements of `<item>`]
@@ -40,7 +40,7 @@ pub struct Item {
     pub categories: Vec<Category>,
     pub comments: Option<String>,
     // pub enclosure
-    // pub guid
+    pub guid: Option<Guid>,
     pub pub_date: Option<String>,  // add a custom String type to parse this date?
     // pub source
 }
@@ -55,6 +55,9 @@ impl ViaXml for Item {
         item.tag_with_optional_text("description", &self.description);
         item.tag_with_optional_text("author", &self.author);
         item.tag_with_optional_text("comments", &self.comments);
+        if let &Some(ref guid) = &self.guid {
+            item.tag(guid.to_xml());
+        }
         item.tag_with_optional_text("pubDate", &self.pub_date);
 
         for category in &self.categories {
@@ -70,6 +73,7 @@ impl ViaXml for Item {
         let description = elem.get_child("description", None).map(Element::content_str);
         let author = elem.get_child("author", None).map(Element::content_str);
         let comments = elem.get_child("comments", None).map(Element::content_str);
+        let guid = elem.get_child("guid", None).map(|e| ViaXml::from_xml(e.clone()).unwrap());
         let pub_date = elem.get_child("pubDate", None).map(Element::content_str);
 
         let categories = elem.get_children("category", None)
@@ -83,6 +87,7 @@ impl ViaXml for Item {
             categories: categories,
             author: author,
             comments: comments,
+            guid: guid,
             pub_date: pub_date,
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@
 //! ```
 
 mod category;
+mod guid;
 mod channel;
 mod item;
 mod text_input;
@@ -81,6 +82,7 @@ use std::str::FromStr;
 use xml::{Element, ElementBuilder, Parser, Xml};
 
 pub use ::category::Category;
+pub use ::guid::Guid;
 pub use ::channel::Channel;
 pub use ::item::Item;
 pub use ::text_input::TextInput;


### PR DESCRIPTION
This is a preliminary impl for [the guid spec](http://cyber.law.harvard.edu/rss/rss.html#ltguidgtSubelementOfLtitemgt)

I'm not sure if we should raise error when `isPermaLink` is a value other than `true` or `false`. Other than that, I tried to copy the impl of `src/category.rs`

I hope it gets merged. Thanks!